### PR TITLE
画像アップロード機能の作成

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   "files.encoding": "utf8",
   "files.eol": "\n",
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "cSpell.words": ["cloudinary"]
 }

--- a/app/routes/hotsprings.new.tsx
+++ b/app/routes/hotsprings.new.tsx
@@ -42,6 +42,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const formData = await parseMultipartFormData(request, uploadHandler);
   const imgUrls = formData.getAll("image");
+  formData.delete("image");
 
   const formDataObj = { ...Object.fromEntries(formData), images: imgUrls };
 

--- a/app/routes/hotsprings.new.tsx
+++ b/app/routes/hotsprings.new.tsx
@@ -1,4 +1,13 @@
-import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import type {
+  UploadHandler,
+  ActionFunctionArgs,
+  LoaderFunctionArgs,
+} from "@remix-run/node";
+import {
+  unstable_parseMultipartFormData as parseMultipartFormData,
+  unstable_composeUploadHandlers as composeUploadHandlers,
+  unstable_createMemoryUploadHandler as createMemoryUploadHandler,
+} from "@remix-run/node";
 import { Form, Link, json, useActionData } from "@remix-run/react";
 import { redirectWithSuccess } from "remix-toast";
 import { Button } from "~/components/ui/button";
@@ -10,6 +19,7 @@ import {
   createHotSpring,
 } from "~/models/hotspring.server";
 import { authenticator } from "~/services/auth.server";
+import { uploadImageToCloudinary } from "~/utils/cloudinary.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   return await authenticator.isAuthenticated(request, {
@@ -18,7 +28,22 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const formDataObj = Object.fromEntries(await request.formData());
+  const uploadHandler: UploadHandler = composeUploadHandlers(
+    async ({ name, data, filename, contentType }) => {
+      if (name !== "image") {
+        return undefined;
+      }
+
+      const uploadedImage = await uploadImageToCloudinary(data); // data: 画像のバイナリデータ
+      return uploadedImage.secure_url;
+    },
+    createMemoryUploadHandler(),
+  );
+
+  const formData = await parseMultipartFormData(request, uploadHandler);
+  const imgUrls = formData.getAll("image");
+
+  const formDataObj = { ...Object.fromEntries(formData), images: imgUrls };
 
   const validationResult = CreateHotSpringSchema.safeParse(formDataObj);
   if (!validationResult.success) {
@@ -48,7 +73,7 @@ export default function CreateRoute() {
     <div className="mx-auto w-full max-w-2xl px-8 py-8 sm:px-20">
       <div className="pb-4 text-center text-2xl font-bold">温泉の新規登録</div>
       <div>
-        <Form method="POST">
+        <Form method="POST" encType="multipart/form-data">
           <div className="mb-4">
             <Label
               htmlFor="title"
@@ -112,10 +137,16 @@ export default function CreateRoute() {
             >
               画像
             </Label>
-            <Input type="file" id="image" name="image" required />
-            {validationMessages?.image && (
+            <Input
+              type="file"
+              id="image"
+              name="image"
+              accept="image/*"
+              multiple
+            />
+            {validationMessages?.images && (
               <p className="text-sm font-bold text-red-500">
-                {validationMessages.image[0]}
+                {validationMessages.images[0]}
               </p>
             )}
           </div>

--- a/app/utils/cloudinary.server.ts
+++ b/app/utils/cloudinary.server.ts
@@ -1,0 +1,41 @@
+import type { UploadApiResponse, UploadStream } from "cloudinary";
+import { writeAsyncIterableToWritable } from "@remix-run/node";
+import cloudinary from "cloudinary";
+
+cloudinary.v2.config({
+  cloud_name: process.env.CLOUD_NAME,
+  api_key: process.env.API_KEY,
+  api_secret: process.env.API_SECRET,
+});
+
+export async function uploadImageToCloudinary(data: AsyncIterable<Uint8Array>) {
+  const uploadPromise = new Promise<UploadApiResponse>(
+    async (resolve, reject) => {
+      const uploadStream: UploadStream = cloudinary.v2.uploader.upload_stream(
+        {
+          folder: "HotSprings",
+        },
+        // アップロード完了時のコールバック
+        (error, result) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          // resultの型エラーを防ぐために記述したが、いいやり方があれば改善したい
+          if (result === undefined) {
+            return;
+          }
+          resolve(result);
+        },
+      );
+
+      // ファイルデータをCloudinaryにアップロード
+      await writeAsyncIterableToWritable(data, uploadStream);
+    },
+  );
+
+  return uploadPromise;
+}
+
+// 環境変数の出力
+// console.log("configs", cloudinary.v2.config());

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@smastrom/react-rating": "^1.5.0",
         "bcrypt": "^5.1.1",
         "class-variance-authority": "^0.7.0",
+        "cloudinary": "^2.0.1",
         "clsx": "^2.1.0",
         "date-fns": "^3.3.1",
         "isbot": "^3.6.8",
@@ -4585,6 +4586,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.0.1.tgz",
+      "integrity": "sha512-+j5GswtCwjAmLhjs/K26id4Zvh53zL/YWzgyenxgbdXdXmdFM8d5H1FV1sJCkpS77AqylJKBzyztySdILM+F+A==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
@@ -8345,8 +8358,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -10843,6 +10855,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@smastrom/react-rating": "^1.5.0",
     "bcrypt": "^5.1.1",
     "class-variance-authority": "^0.7.0",
+    "cloudinary": "^2.0.1",
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",
     "isbot": "^3.6.8",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,18 +11,27 @@ datasource db {
 }
 
 model HotSpring {
-  id          String   @id @default(uuid())
+  id          String           @id @default(uuid())
   title       String
   description String
   price       Int
   location    String
-  url         String?
-  filename    String?
-  Author      User     @relation(fields: [authorId], references: [id])
+  images      HotSpringImage[]
+  Author      User             @relation(fields: [authorId], references: [id])
   authorId    String
   reviews     Review[]
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+}
+
+model HotSpringImage {
+  id          String     @id @default(uuid())
+  url         String?
+  filename    String?
+  HotSpring   HotSpring? @relation(fields: [hotSpringId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  hotSpringId String?
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
 }
 
 model Review {


### PR DESCRIPTION
# issueURL

#16 

# 関連 URL

- https://remix.run/docs/en/main/guides/file-uploads
- https://github.com/remix-run/examples/tree/main/file-and-cloudinary-upload

# このPRで対応すること / このPRで対応しないこと

- 対応内容
  - #16 の完了の定義をすべて対応する
- 対応しないこと
  - 編集画面の画像の更新
  - 温泉情報を削除した際に、関連のあるCloudinary側の画像の削除処理
 
# 変更点概要

- Cloudinary側に画像をアップロードする機能追加（複数画像対応)
- 画像情報を保管するように`HotSpringImage`テーブルを追加した

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

画像アップロード機能は作れたが、バリデーション周りの改善は今後必要だと思う。
ファイルサイズの制限や画像ファイルかどうか？なども考慮したい。
