### PR TITLE
画像アップロードと画像削除の機能作成

### DIFF
--- a/app/models/hotspring.server.ts
+++ b/app/models/hotspring.server.ts
@@ -53,6 +53,17 @@ export async function getHotSprings() {
   });
 }
 
+export async function getPublicIds(id: HotSpring["id"]) {
+  return prisma.hotSpringImage.findMany({
+    where: {
+      hotSpringId: id,
+    },
+    select: {
+      publicId: true,
+    },
+  });
+}
+
 // TODO: ファイルのバリデーションは今後実装してみたい
 // const MAX_UPLOAD_SIZE = 1024 * 1024 * 3; // 3MB
 // const ImageFieldSchema = z.object({

--- a/app/models/hotspring.server.ts
+++ b/app/models/hotspring.server.ts
@@ -32,6 +32,7 @@ export async function getHotSpring(id: HotSpring["id"]) {
     where: { id },
     include: {
       Author: true,
+      images: true,
     },
   });
 }
@@ -71,8 +72,11 @@ export const CreateHotSpringSchema = z.object({
   price: z.coerce.number().min(1, "1以上の数値を指定してください"),
   location: z.string(),
   images: z
-    .array(z.string())
-    .max(5, "ファイルは最大5つまでしかアップロードできません。"),
+    .object({
+      url: z.string(),
+      publicId: z.string(),
+    })
+    .array(),
 });
 
 export async function createHotSpring({
@@ -93,7 +97,7 @@ export async function createHotSpring({
         images: {
           createMany: {
             data: images.map((image) => {
-              return { url: image };
+              return { url: image.url, publicId: image.publicId };
             }),
           },
         },

--- a/app/routes/hotsprings.$id.tsx
+++ b/app/routes/hotsprings.$id.tsx
@@ -45,21 +45,6 @@ import {
   AlertDialogTrigger,
 } from "~/components/ui/alert-dialog";
 
-export const IMAGES = [
-  {
-    id: 1,
-    src: "https://source.unsplash.com/body-of-water-on-near-rocks-UHcwyq05_Gk",
-  },
-  {
-    id: 2,
-    src: "https://source.unsplash.com/body-of-water-on-near-rocks-UHcwyq05_Gk",
-  },
-  {
-    id: 3,
-    src: "https://source.unsplash.com/body-of-water-on-near-rocks-UHcwyq05_Gk",
-  },
-];
-
 const INTENTS = {
   deleteHotSpringIntent: "deleteHotSpring" as const,
   createReviewIntent: "createReview" as const,
@@ -115,13 +100,13 @@ export default function HotSpringRoute() {
           <Card>
             <ScrollArea>
               <div className="flex gap-x-4 px-4 pt-4">
-                {IMAGES.map((image) => {
+                {hotSpring.images.map((image) => {
                   return (
                     <img
                       key={image.id}
-                      src={image.src}
+                      src={image.url}
                       alt={`${hotSpring.title}の画像`}
-                      className="rounded-md"
+                      className="border"
                     />
                   );
                 })}

--- a/app/routes/hotsprings.$id.tsx
+++ b/app/routes/hotsprings.$id.tsx
@@ -25,7 +25,11 @@ import { ScrollArea, ScrollBar } from "~/components/ui/scroll-area";
 import { Separator } from "~/components/ui/separator";
 import { Textarea } from "~/components/ui/textarea";
 import { authenticator } from "~/services/auth.server";
-import { deleteHotSpring, getHotSpring } from "~/models/hotspring.server";
+import {
+  getHotSpring,
+  getPublicIds,
+  deleteHotSpring,
+} from "~/models/hotspring.server";
 import {
   CreateReviewSchema,
   createReview,
@@ -44,6 +48,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "~/components/ui/alert-dialog";
+import { deleteImageById } from "~/utils/cloudinary.server";
 
 const INTENTS = {
   deleteHotSpringIntent: "deleteHotSpring" as const,
@@ -273,6 +278,16 @@ async function deleteHotSpringAction({ params }: { params: Params<string> }) {
   const hotSpringId = params.id;
   invariant(hotSpringId, "Invalid params");
 
+  // 温泉情報に紐づくpublic_idをすべて取得
+  const publicIds = await getPublicIds(hotSpringId);
+  console.log(publicIds);
+
+  // Cloudinary上から対象画像を削除
+  publicIds.forEach(async ({ publicId }) => {
+    await deleteImageById(publicId);
+  });
+
+  // 温泉情報のレコード削除
   await deleteHotSpring(hotSpringId);
 
   return redirectWithSuccess("/hotsprings", "温泉情報が削除されました！🔥");

--- a/app/routes/hotsprings.$id_.edit.tsx
+++ b/app/routes/hotsprings.$id_.edit.tsx
@@ -158,8 +158,42 @@ export default function EditRoute() {
             >
               画像
             </Label>
-            <Input type="file" id="image" name="image" required />
+            <Input type="file" id="image" name="image" />
           </div>
+
+          <div>
+            <Label
+              htmlFor="uploadedImage"
+              className="mb-2 block text-sm font-medium text-gray-600"
+            >
+              アップロード済み画像
+            </Label>
+            <div className="flex gap-x-2">
+              {hotSpring.images.map((image) => {
+                return (
+                  <div key={image.id}>
+                    <img
+                      src={image.url}
+                      alt={`温泉の写真${image.id}`}
+                      className="size-32 rounded-md border border-muted object-cover"
+                    />
+                    <div className="flex items-center gap-x-1">
+                      <input
+                        type="checkbox"
+                        name="deleteImages[]"
+                        id={`image${image.id}`}
+                        value={image.publicId}
+                      />
+                      <Label htmlFor={`image${image.id}`} className="text-sm">
+                        削除する
+                      </Label>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
           <div className="mt-8">
             <Button type="submit" className="w-full">
               更新する

--- a/app/routes/hotsprings.new.tsx
+++ b/app/routes/hotsprings.new.tsx
@@ -19,10 +19,7 @@ import {
   createHotSpring,
 } from "~/models/hotspring.server";
 import { authenticator } from "~/services/auth.server";
-import {
-  CLOUDINARY_FOLDER_NAME,
-  uploadImageToCloudinary,
-} from "~/utils/cloudinary.server";
+import { uploadImageToCloudinary } from "~/utils/cloudinary.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   return await authenticator.isAuthenticated(request, {
@@ -179,7 +176,7 @@ function createImagesObject(urls: FormDataEntryValue[], ids: string[]) {
   return urls.map((url, index) => {
     return {
       url,
-      publicId: ids[index].replace(`${CLOUDINARY_FOLDER_NAME}/`, ""), // 先頭のフォルダ名を削除
+      publicId: ids[index],
     };
   });
 }

--- a/app/utils/cloudinary.server.ts
+++ b/app/utils/cloudinary.server.ts
@@ -8,12 +8,15 @@ cloudinary.v2.config({
   api_secret: process.env.API_SECRET,
 });
 
+export const CLOUDINARY_FOLDER_NAME = "HotSprings";
+
 export async function uploadImageToCloudinary(data: AsyncIterable<Uint8Array>) {
   const uploadPromise = new Promise<UploadApiResponse>(
     async (resolve, reject) => {
       const uploadStream: UploadStream = cloudinary.v2.uploader.upload_stream(
         {
-          folder: "HotSprings",
+          folder: CLOUDINARY_FOLDER_NAME,
+          unique_filename: true,
         },
         // アップロード完了時のコールバック
         (error, result) => {

--- a/app/utils/cloudinary.server.ts
+++ b/app/utils/cloudinary.server.ts
@@ -40,5 +40,18 @@ export async function uploadImageToCloudinary(data: AsyncIterable<Uint8Array>) {
   return uploadPromise;
 }
 
+// 特定のpublic_idを持つ画像を削除する
+export async function deleteImageById(id: string) {
+  try {
+    const result: { result: string } = await cloudinary.v2.uploader.destroy(id);
+    if (result.result !== "ok") {
+      throw new Error("画像の削除に失敗しました");
+    }
+  } catch (error) {
+    console.log(error);
+    throw new Error("Unexpected error");
+  }
+}
+
 // 環境変数の出力
 // console.log("configs", cloudinary.v2.config());

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model HotSpring {
 model HotSpringImage {
   id          String     @id @default(uuid())
   url         String
+  publicId    String
   filename    String?
   HotSpring   HotSpring? @relation(fields: [hotSpringId], references: [id], onDelete: Cascade, onUpdate: Cascade)
   hotSpringId String?


### PR DESCRIPTION
# issueURL

#36 

# 関連 URL

特になし

# このPRで対応すること / このPRで対応しないこと

#36 の完了の定義をすべて対応する

# 変更点概要

- 画像アップロード時に外部ストレージ上の画像の識別子(public_id)をDBに保存する処理の追加
- 温泉削除時の画像削除
- アップロード画像の表示

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
