### PR TITLE
認証処理の見直しと認証有無に応じたヘッダーの見た目の切り替え

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -40,6 +40,8 @@ export async function createUser({
       },
     });
   } catch (error) {
+    // Prismaの一意制約エラーを拾う処理
+    // https://www.prisma.io/docs/orm/reference/error-reference#error-codes
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === "P2002"

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -39,11 +39,11 @@ export default function App() {
   const links = user
     ? [
         { text: "ホーム", to: "/" },
-        { text: "温泉", to: "/hotsprings" },
+        { text: "温泉リスト", to: "/hotsprings" },
       ]
     : [
         { text: "ホーム", to: "/" },
-        { text: "温泉", to: "/hotsprings" },
+        { text: "温泉リスト", to: "/hotsprings" },
         { text: "新規登録", to: "/register" },
         { text: "ログイン", to: "/login" },
       ];

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,6 +17,7 @@ import { useEffect } from "react";
 import { getToast } from "remix-toast";
 import { toast as notify } from "sonner";
 import { Toaster } from "~/components/ui/sonner";
+import { authenticator } from "~/services/auth.server";
 import cssStyles from "@smastrom/react-rating/style.css";
 import tailwindStyles from "./tailwind.css";
 
@@ -26,12 +27,26 @@ export const links: LinksFunction = () => [
 ];
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const user = await authenticator.isAuthenticated(request);
   const { toast, headers } = await getToast(request);
-  return json({ toast }, { headers });
+  return json({ user, toast }, { headers });
 };
 
 export default function App() {
-  const { toast } = useLoaderData<typeof loader>();
+  const { user, toast } = useLoaderData<typeof loader>();
+
+  // セッション有無に応じてヘッダーのリンクを切り替える
+  const links = user
+    ? [
+        { text: "ホーム", to: "/" },
+        { text: "温泉", to: "/hotsprings" },
+      ]
+    : [
+        { text: "ホーム", to: "/" },
+        { text: "温泉", to: "/hotsprings" },
+        { text: "新規登録", to: "/register" },
+        { text: "ログイン", to: "/login" },
+      ];
 
   useEffect(() => {
     if (toast?.type === "error") {
@@ -42,16 +57,8 @@ export default function App() {
     }
   }, [toast]);
 
-  // TODO: session有無に応じて、要素を切り替える
-  const links = [
-    { text: "ホーム", to: "/" },
-    { text: "温泉", to: "/hotsprings" },
-    { text: "新規登録", to: "/register" },
-    { text: "ログイン", to: "/login" },
-  ];
-
   return (
-    <Document>
+    <Document title="YelpHotSpring">
       <div className="flex min-h-screen flex-col justify-between">
         <header className="bg-gray-800 px-8 py-4">
           <nav>
@@ -71,12 +78,14 @@ export default function App() {
                     {link.text}
                   </Link>
                 ))}
-                {/* TODO:セッションが存在する場合、ログアウトボタン表示 */}
-                <Form action="/logout" method="post">
-                  <button className="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white">
-                    ログアウト
-                  </button>
-                </Form>
+                {/* セッションが存在する場合、ログアウトボタン表示 */}
+                {user && (
+                  <Form action="/logout" method="post">
+                    <button className="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white">
+                      ログアウト
+                    </button>
+                  </Form>
+                )}
               </div>
             </div>
           </nav>
@@ -88,7 +97,7 @@ export default function App() {
 
         <footer className="bg-gray-800 px-8 py-4 text-white">
           <div className="flex justify-center">
-            <small>&copy; 2024 example</small>
+            <small>&copy; 2024 otaki</small>
           </div>
         </footer>
       </div>

--- a/app/routes/hotsprings.$id.tsx
+++ b/app/routes/hotsprings.$id.tsx
@@ -7,7 +7,11 @@ import {
   useActionData,
   useLoaderData,
 } from "@remix-run/react";
-import { jsonWithSuccess, redirectWithSuccess } from "remix-toast";
+import {
+  jsonWithSuccess,
+  redirectWithError,
+  redirectWithSuccess,
+} from "remix-toast";
 import { Rating } from "@smastrom/react-rating";
 import invariant from "tiny-invariant";
 import { format } from "date-fns";
@@ -57,10 +61,8 @@ const INTENTS = {
 };
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
-  // TODO: 認証せずとも閲覧はできるようにしたい
-  const currentUser = await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
+  const currentUser = await authenticator.isAuthenticated(request);
+
   const hotSpringId = params.id;
   invariant(hotSpringId, "Invalid params");
 
@@ -144,7 +146,7 @@ export default function HotSpringRoute() {
                 {format(hotSpring.updatedAt, "yyyy年MM月dd日 HH時MM分")}
               </div>
               {/* ログインユーザーとレビュアーが一致している場合、編集・削除ボタン表示 */}
-              {hotSpring.Author.id === currentUser.id && (
+              {hotSpring.Author.id === currentUser?.id && (
                 <div className="flex gap-2">
                   <Link to="edit">
                     <Button variant="outline">編集</Button>
@@ -241,7 +243,7 @@ export default function HotSpringRoute() {
                           {review.Reviewer.username}
                         </div>
                         {/* ログインユーザーとレビュアーが一致している場合、削除ボタン表示 */}
-                        {currentUser.id === review.reviewerId && (
+                        {currentUser?.id === review.reviewerId && (
                           <Button
                             variant="ghost"
                             size="icon"
@@ -314,9 +316,10 @@ async function createReviewAction({
     });
   }
 
-  const user = await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
+  const user = await authenticator.isAuthenticated(request);
+  if (user === null) {
+    return redirectWithError("/login", "ログインが必要な操作です！🚧");
+  }
 
   await createReview({
     reviewerId: user.id,

--- a/app/routes/hotsprings.$id.tsx
+++ b/app/routes/hotsprings.$id.tsx
@@ -77,14 +77,14 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 };
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
-  const formData = await request.clone().formData();
-  const intent = formData.get("intent");
-
-  // 認証されていない場合はnullを返す
+  // 認証されていない場合はnullが返されるので、ログインページへリダイレクト
   const user = await authenticator.isAuthenticated(request);
   if (user === null) {
     return redirectWithError("/login", "ログインが必要な操作です！🚧");
   }
+
+  const formData = await request.clone().formData();
+  const intent = formData.get("intent");
 
   switch (intent) {
     case INTENTS.deleteHotSpringIntent: {

--- a/app/routes/hotsprings.$id_.edit.tsx
+++ b/app/routes/hotsprings.$id_.edit.tsx
@@ -15,7 +15,7 @@ import {
   useActionData,
   useLoaderData,
 } from "@remix-run/react";
-import { redirectWithSuccess } from "remix-toast";
+import { redirectWithError, redirectWithSuccess } from "remix-toast";
 import invariant from "tiny-invariant";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
@@ -36,9 +36,11 @@ import {
 } from "~/utils/cloudinary.server";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
-  await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
+  const user = await authenticator.isAuthenticated(request);
+  // TODO: 下記トースターが2回実行されるのはなぜか分からないので調査中
+  if (user === null) {
+    return redirectWithError("/login", "ログインが必要なルートです！🚧");
+  }
   const hotSpringId = params.id;
   invariant(hotSpringId, "Invalid params");
 
@@ -51,9 +53,10 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 };
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
-  await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
+  const user = await authenticator.isAuthenticated(request);
+  if (user === null) {
+    return redirectWithError("/login", "ログインが必要な操作です！🚧");
+  }
 
   const hotSpringId = params.id;
   invariant(hotSpringId, "Invalid params");

--- a/app/routes/hotsprings._index.tsx
+++ b/app/routes/hotsprings._index.tsx
@@ -12,13 +12,8 @@ import {
 } from "~/components/ui/card";
 import { getHotSprings } from "~/models/hotspring.server";
 import { getRatingAvg } from "~/models/review.server";
-import { authenticator } from "~/services/auth.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
-
   const hotSprings = await getHotSprings();
   const hotSpringsWithAvg = await Promise.all(
     hotSprings.map(async (hotSpring) => {

--- a/app/routes/hotsprings._index.tsx
+++ b/app/routes/hotsprings._index.tsx
@@ -36,7 +36,7 @@ export default function HotSpringsIndexRoute() {
       <div className="pb-4 text-center text-2xl font-bold">温泉リスト</div>
       <div className="mb-4 flex justify-end">
         <Button asChild variant="outline">
-          <Link to="new">新規登録へ</Link>
+          <Link to="/hotsprings/new">温泉登録へ</Link>
         </Button>
       </div>
       <div className="grid w-full grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">

--- a/app/routes/hotsprings.new.tsx
+++ b/app/routes/hotsprings.new.tsx
@@ -9,7 +9,7 @@ import {
   unstable_createMemoryUploadHandler as createMemoryUploadHandler,
 } from "@remix-run/node";
 import { Form, Link, json, useActionData } from "@remix-run/react";
-import { redirectWithSuccess } from "remix-toast";
+import { redirectWithError, redirectWithSuccess } from "remix-toast";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
@@ -22,12 +22,17 @@ import { authenticator } from "~/services/auth.server";
 import { uploadImageToCloudinary } from "~/utils/cloudinary.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  return await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
+  const user = await authenticator.isAuthenticated(request);
+  if (user === null) {
+    return redirectWithError("/login", "ログインが必要なルートです！🚧");
+  }
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  const user = await authenticator.isAuthenticated(request);
+  if (user === null) {
+    return redirectWithError("/login", "ログインが必要な操作です！🚧");
+  }
   // TODO: 現状Cloudinaryのpublic_idを適切に取得する方法がわからないので、暫定対処として配列に格納する
   const imgIds: string[] = [];
 
@@ -56,10 +61,6 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       validationErrors: validationResult.error.flatten().fieldErrors,
     });
   }
-
-  const user = await authenticator.isAuthenticated(request, {
-    failureRedirect: "/login",
-  });
 
   const newHotSpring = await createHotSpring({
     ...validationResult.data,

--- a/app/routes/hotsprings.new.tsx
+++ b/app/routes/hotsprings.new.tsx
@@ -67,7 +67,10 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   });
 
   // TODO: 第3引数にいれるべきかが分からないため調査する
-  return redirectWithSuccess("/", `${newHotSpring.title}を登録しました。`);
+  return redirectWithSuccess(
+    `/hotsprings`,
+    `${newHotSpring.title}を登録しました！🎉`,
+  );
 };
 
 export default function CreateRoute() {

--- a/app/routes/hotsprings.new.tsx
+++ b/app/routes/hotsprings.new.tsx
@@ -26,6 +26,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (user === null) {
     return redirectWithError("/login", "ログインが必要なルートです！🚧");
   }
+  return null;
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,16 +1,15 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
-import { Form } from "@remix-run/react";
+import { Form, json, useActionData } from "@remix-run/react";
+import { AuthorizationError } from "remix-auth";
+import { redirectWithError } from "remix-toast";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
-import { AUTH_STRATEGY_NAME, authenticator } from "~/services/auth.server";
-
-export const action = async ({ request }: ActionFunctionArgs) => {
-  return await authenticator.authenticate(AUTH_STRATEGY_NAME, request, {
-    successRedirect: "/hotsprings",
-    failureRedirect: "/login",
-  });
-};
+import {
+  AUTH_STRATEGY_NAME,
+  AuthSchema,
+  authenticator,
+} from "~/services/auth.server";
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   return await authenticator.isAuthenticated(request, {
@@ -18,7 +17,39 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   });
 };
 
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const cloneRequest = request.clone();
+  const formDataObj = Object.fromEntries(await cloneRequest.formData());
+
+  const validationResult = AuthSchema.safeParse(formDataObj);
+  if (!validationResult.success) {
+    return json({
+      error: null,
+      validationErrors: validationResult.error.flatten().fieldErrors,
+    });
+  }
+
+  try {
+    // 認証失敗時のリダイレクト先を指定しないことで、nullを返さず意図的にAuthorizationErrorを出す
+    return await authenticator.authenticate(AUTH_STRATEGY_NAME, request, {
+      successRedirect: "/hotsprings",
+      throwOnError: true,
+    });
+  } catch (error) {
+    // 認証成功時には、Responseのerrorを返すことで正常なリダイレクトを行う
+    if (error instanceof Response) return error;
+    if (error instanceof AuthorizationError) {
+      return redirectWithError("/login", error.message);
+    }
+    console.log(error);
+    throw new Error("Unexpected Error");
+  }
+};
+
 export default function Login() {
+  const actionData = useActionData<typeof action>();
+  const validationMessages = actionData?.validationErrors;
+
   return (
     <div className="flex min-h-full items-center justify-center py-40">
       <div className="w-full rounded border p-8 shadow-md sm:mx-auto sm:max-w-md">
@@ -32,6 +63,11 @@ export default function Login() {
               メールアドレス
             </Label>
             <Input type="email" id="email" name="email" required />
+            {validationMessages?.email && (
+              <p className="text-sm font-bold text-red-500">
+                {validationMessages.email[0]}
+              </p>
+            )}
           </div>
 
           <div className="mb-4">
@@ -39,6 +75,11 @@ export default function Login() {
               パスワード
             </Label>
             <Input type="password" id="password" name="password" />
+            {validationMessages?.password && (
+              <p className="text-sm font-bold text-red-500">
+                {validationMessages.password[0]}
+              </p>
+            )}
           </div>
           <div className="mt-8">
             <Button className="w-full">ログイン</Button>

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -1,10 +1,17 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { Form, json, useActionData } from "@remix-run/react";
+import { jsonWithError } from "remix-toast";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Label } from "~/components/ui/label";
 import { CreateUserSchema, createUser } from "~/models/user.server";
 import { AUTH_STRATEGY_NAME, authenticator } from "~/services/auth.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  return await authenticator.isAuthenticated(request, {
+    successRedirect: "/hotsprings",
+  });
+};
 
 export async function action({ request }: ActionFunctionArgs) {
   // MEMO: remix-auth側でrequestを使用しているため、ここでcloneする
@@ -21,23 +28,13 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const result = await createUser(validationResult.data);
   if (result?.error) {
-    return json({
-      error: result.error,
-      validationErrors: null,
-    });
+    return jsonWithError(null, result.error);
   }
 
   return await authenticator.authenticate(AUTH_STRATEGY_NAME, request, {
     successRedirect: "/hotsprings",
-    failureRedirect: "/login",
   });
 }
-
-export const loader = async ({ request }: LoaderFunctionArgs) => {
-  return await authenticator.isAuthenticated(request, {
-    successRedirect: "/hotsprings",
-  });
-};
 
 export default function Register() {
   const actionData = useActionData<typeof action>();


### PR DESCRIPTION
# issueURL

#39 

# 関連 URL

特になし

# このPRで対応すること / このPRで対応しないこと

- 対応すること
  - #39 



# 変更点概要

- 認証失敗時にトースターを表示させるようにした
- loader関数とaction関数の上部で認証を通すようにした(温泉登録は未対応)
- 認証有無に応じてヘッダーの表示切り替えるようにした

# レビュアーに重点的にチェックして欲しい点

特になし

# 補足情報

特になし
